### PR TITLE
Fix CI folder in solution and retarget publish profile

### DIFF
--- a/SourceEngine.Demo.sln
+++ b/SourceEngine.Demo.sln
@@ -24,6 +24,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ci", "ci", "{7DC9398B-B4EB-4D1C-8645-D74A2AC5D09D}"
+	ProjectSection(SolutionItems) = preProject
+		azure-pipelines.yml = azure-pipelines.yml
+		ci\build.yml = ci\build.yml
+		ci\check_version.ps1 = ci\check_version.ps1
+		ci\deploy.yml = ci\deploy.yml
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C852A71E-BBF3-4D71-8B11-D244C1751EF3}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/SourceEngine.Demo.Stats.App/Properties/PublishProfiles/win_x64_self_contained.pubxml
+++ b/src/SourceEngine.Demo.Stats.App/Properties/PublishProfiles/win_x64_self_contained.pubxml
@@ -10,8 +10,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PublishDir>bin\Release\netcoreapp3.1\win-x64\publish\</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <SelfContained>false</SelfContained>
-    <PublishSingleFile>False</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>True</PublishSingleFile>
     <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The CI folder had an incorrect path specified for `azure-pipelines.yml` and Visual Studio complained. This has now been fixed.

Using the included publish profile within Visual Studio was broken because I forgot to retarget it to .NET Core 3.1 when I updated the whole project from 3.0.