### PR TITLE
Pack and publish the Parser

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
         <Company>Source Engine Discord</Company>
         <Copyright>© 2014 EHVAG, 2020 Source Engine Discord and contributors</Copyright>
         <Product>SourceEngine.Demo</Product>
-        <Version>2.0.2</Version>
+        <Version>2.0.3</Version>
     </PropertyGroup>
 
     <PropertyGroup Label="Package Metadata">

--- a/src/SourceEngine.Demo.Parser/SourceEngine.Demo.Parser.csproj
+++ b/src/SourceEngine.Demo.Parser/SourceEngine.Demo.Parser.csproj
@@ -35,10 +35,6 @@
         <DebugSymbols>true</DebugSymbols>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
-
     <ItemGroup>
         <None Remove="packages.lock.json" />
     </ItemGroup>


### PR DESCRIPTION
The Parser project was not being included in the NuGet package. Since it's not published anywhere, the purpose of using a NuGet package was effectively defeated.